### PR TITLE
Allow to configure the ROOT option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,20 @@ Take login token from sonarqube server, change working directory to project dire
 docker run --name dotnet-scanner -it --rm -v $(pwd):/project \
   -e PROJECT_KEY=ConsoleApplication1 \
   -e PROJECT_NAME=ConsoleApplication1 \
+  -e PROJECT_VERSION=1.0 \  
+  -e HOST=http://localhost:9000 \
+  -e LOGIN_KEY=CHANGE_THIS_ONE \
+  burakince/docker-dotnet-sonarscanner
+```
+
+More than one project or solution file in working directory
+
+```
+docker run --name dotnet-scanner -it --rm -v $(pwd):/project \
+  -e PROJECT_KEY=ConsoleApplication1 \
+  -e PROJECT_NAME=ConsoleApplication1 \
   -e PROJECT_VERSION=1.0 \
+  -e PROJECT_FILE=ConsoleApplication1.sln \
   -e HOST=http://localhost:9000 \
   -e LOGIN_KEY=CHANGE_THIS_ONE \
   burakince/docker-dotnet-sonarscanner

--- a/run.sh
+++ b/run.sh
@@ -5,11 +5,20 @@ set -x
 PROJECT_KEY="${PROJECT_KEY:-ConsoleApplication1}"
 PROJECT_NAME="${PROJECT_NAME:-ConsoleApplication1}"
 PROJECT_VERSION="${PROJECT_VERSION:-1.0}"
+PROJECT_FILE="${PROJECT_FILE:-}"
 SONAR_HOST="${HOST:-http://localhost:9000}"
 SONAR_LOGIN_KEY="${LOGIN_KEY:-admin}"
 
 mono /opt/sonar-scanner-msbuild/SonarScanner.MSBuild.exe begin /d:sonar.host.url=$SONAR_HOST /d:sonar.login=$SONAR_LOGIN_KEY /k:$PROJECT_KEY /n:"$PROJECT_NAME" /v:$PROJECT_VERSION
-dotnet restore
-dotnet build
-dotnet test
+
+if [ "$PROJECT_FILE" == "" ]; then
+	dotnet restore
+	dotnet build
+	dotnet test
+else
+	dotnet restore $PROJECT_FILE
+	dotnet build $PROJECT_FILE
+	dotnet test $PROJECT_FILE	
+fi
+
 mono /opt/sonar-scanner-msbuild/SonarScanner.MSBuild.exe end /d:sonar.login=$SONAR_LOGIN_KEY


### PR DESCRIPTION
Hi @burakince,

Thanks for your repo. It's great!
When I used it for my Jenkins, I got the issue about the project file not found when trying to run it with multiple projects or solutions in the working directory.

> error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file

I suggest we have an option to allow us to choose the PROJECT_FILE option when executing

Regards,
Hai Vo
